### PR TITLE
New Storage Format

### DIFF
--- a/Sources/BTree/BTree.swift
+++ b/Sources/BTree/BTree.swift
@@ -133,7 +133,7 @@ public final class BTreeNode<Key: Comparable & Codable, Value: Codable>: Codable
     public var isLoaded = false
     
     /// Offset of this node in storage engine
-    public var offset: Int? = nil
+    public var offset: UInt64? = nil
     
     public weak var parent: BTreeNode<Key, Value>?
     
@@ -160,9 +160,15 @@ public final class BTreeNode<Key: Comparable & Codable, Value: Codable>: Codable
         self.minimumDegree = try values.decode(Int.self, forKey: .minimumDegree)
         self.isLeaf = try values.decode(Bool.self, forKey: .isLeaf)
         
-        let decodedChildren = try values.decode([Int].self, forKey: .children)
         
-        self.children = decodedChildren.map({ (childOffset) -> BTreeNode<Key, Value> in
+        let decodedChildren = try values.decode([String].self, forKey: .children)
+        
+        self.children = try decodedChildren.map({ (childOffsetString) -> BTreeNode<Key, Value> in
+            guard let childOffset = UInt64(childOffsetString) else {
+                throw BTreeError.invalidRecord
+                
+            }
+            
             let child = BTreeNode(minimumDegree: self.minimumDegree, isLeaf: self.isLeaf)
             child.offset = childOffset
             
@@ -396,10 +402,11 @@ enum BTreeError: Error {
     case nodeIsNotLoaded
     case unableToLoadNode
     case unableToReadDatabase
-    case unableToCreateDatabase
+    case unableToCreateStorage
     case unableToModifyTemporaryDatabase
     case unableToRenameTemporaryDatabase
-    case invalidDatabase
+    case invalidStorage
     case invalidRootRecord
     case invalidRecord
+    case invalidRecordSize
 }

--- a/Sources/BTree/BTree.swift
+++ b/Sources/BTree/BTree.swift
@@ -321,7 +321,7 @@ public final class BTreeNode<Key: Comparable & Codable, Value: Codable>: Codable
         var container = encoder.container(keyedBy: CodingKeys.self)
         
         try container.encode(self.elements, forKey: .elements)
-        try container.encode(self.children.map { $0.offset! }, forKey: .children)
+        try container.encode(self.children.map { $0.offset!.toPaddedString() }, forKey: .children)
         try container.encode(self.minimumDegree, forKey: .minimumDegree)
         try container.encode(self.isLeaf, forKey: .isLeaf)
         

--- a/Sources/BTree/Storage.swift
+++ b/Sources/BTree/Storage.swift
@@ -103,7 +103,7 @@ public class Storage<Key: Comparable & Codable, Value: Codable> {
         }
 
         if self.isEmpty() {
-            let zeroes = 0.toPaddedString()
+            let zeroes = 0.toPaddedString() + "\n"
             self.file.write(zeroes.data(using: .utf8)!)
 
         }

--- a/Sources/BTree/Storage.swift
+++ b/Sources/BTree/Storage.swift
@@ -17,17 +17,18 @@ public class Storage<Key: Comparable & Codable, Value: Codable> {
     /// File the B-Tree is stored  in
     private var file: FileHandle
 
-    // TODO: Make these init parameters
-    /// Amount to read from disk at a time
-    private let chunkSize = 4096
-
     /// Delimiter records are split by on disk
     private let recordDelimiter = "\n"
     private let recordDelimiterAsData: Data
-
-    /// Delimiter ids are split by on disk
-    private let idDelimiter = ";"
-    private let idDelimiterAsData: Data
+    
+    /// Offset in storage where records begin
+    private let startOfRecords = 21
+    
+    /// The length in bytes of the root record pointer
+    private let rootRecordPointerSize = 19
+    
+    /// The length in bytes of a record size
+    private let lengthOfRecordSize = 19
 
     /// The encoding to use on disk
     private let encoding = String.Encoding.utf8
@@ -40,36 +41,35 @@ public class Storage<Key: Comparable & Codable, Value: Codable> {
 
     // MARK: Construction & Deconstruction
 
-    /// Setups up this storage engine. Creates a new DB if one is not current at the given location.
+    /// Setups up this storage engine. Creates a new storage file if one is not current at the given location.
     ///
     /// - parameter path: Location on disk to store a B-Tree.
-    /// - throws: `BTreeError.unableToCreateDatabase` if unable to write to disk
+    /// - throws: `BTreeError.unableToCreateStorage` if unable to write to disk
     public init(path: URL) throws {
         self.path = path
 
-        // Load DB, if it exists
+        // Load storage file, if it exists
         do {
             self.file = try FileHandle(forUpdating: path)
 
         } catch {
-            // Create new DB if no DB exists at given path
+            // Create new storage file if no storage file exists at given path
             do {
                 try "".write(to: path, atomically: true, encoding: .utf8)
                 self.file = try FileHandle(forUpdating: path)
 
             } catch {
-                throw BTreeError.unableToCreateDatabase
+                throw BTreeError.unableToCreateStorage
 
             }
 
         }
 
         self.recordDelimiterAsData = self.recordDelimiter.data(using: .utf8)!
-        self.idDelimiterAsData = self.idDelimiter.data(using: .utf8)!
 
     }
 
-    /// Close the database file on deinit
+    /// Close the storage file on deinit
     deinit {
         self.close()
 
@@ -96,14 +96,14 @@ public class Storage<Key: Comparable & Codable, Value: Codable> {
     /// - parameter node: Node to store as new root
     /// - returns: The offset of the root node in storage
     /// - throws: If unable to load the given node, or unable to write to disk
-    public func saveRoot(_ node: BTreeNode<Key, Value>) throws -> Int {
+    public func saveRoot(_ node: BTreeNode<Key, Value>) throws -> UInt64 {
         if !node.isLoaded {
             throw BTreeError.nodeIsNotLoaded
 
         }
 
         if self.isEmpty() {
-            let zeroes = String(format: "%016d\n", 0)
+            let zeroes = 0.toPaddedString()
             self.file.write(zeroes.data(using: .utf8)!)
 
         }
@@ -112,7 +112,7 @@ public class Storage<Key: Comparable & Codable, Value: Codable> {
 
         self.file.seek(toFileOffset: 0)
 
-        let offsetWithLeadingZeroes = String(format: "%016d\n", offset)
+        let offsetWithLeadingZeroes = offset.toPaddedString()
         self.file.write(offsetWithLeadingZeroes.data(using: .utf8)!)
 
         return offset
@@ -122,22 +122,25 @@ public class Storage<Key: Comparable & Codable, Value: Codable> {
     /// Read the current root from disk
     ///
     /// - returns: The root node
-    /// - throws: If database is corrupted, if root record is corrupted
+    /// - throws: If storage is corrupted, if root record is corrupted
     public func readRootNode() throws -> BTreeNode<Key, Value> {
         self.file.seek(toFileOffset: 0)
 
-        let buffer = self.file.readData(ofLength: 17)
-        let offsetData = buffer.subdata(in: 0..<buffer.firstIndex(of: "\n".data(using: .utf8)!.bytes[0])!)
-        let maybeOffset = Int(String(data: offsetData, encoding: .utf8)!)
-
-        guard let offset = maybeOffset else {
-            throw BTreeError.invalidDatabase
-
+        let rootRecordOffsetData = self.file.readData(ofLength: rootRecordPointerSize)
+                
+        guard let rootRecordOffsetString = String(data: rootRecordOffsetData, encoding: .utf8) else {
+            throw BTreeError.invalidRecordSize
+            
+        }
+        
+        guard let rootRecordOffset = UInt64(rootRecordOffsetString) else {
+            throw BTreeError.invalidRecordSize
+            
         }
 
         do {
-            let rootNode = try self.findNode(withOffset: offset)
-            rootNode.offset = offset
+            let rootNode = try self.findNode(withOffset: rootRecordOffset)
+            rootNode.offset = rootRecordOffset
             return rootNode
 
         } catch {
@@ -153,17 +156,22 @@ public class Storage<Key: Comparable & Codable, Value: Codable> {
     /// - parameter offset: The offset of the node w want to retrieve on disk
     /// - returns: The node, if it found on disk. Otherwise, nil
     /// - throws: If record is corrupted
-    public func findNode(withOffset offset: Int) throws -> BTreeNode<Key, Value> {
-        self.file.seek(toFileOffset: UInt64(offset))
-
-        var buffer = Data()
-
-        while buffer.firstIndex(of: "\n".data(using: .utf8)!.bytes[0]) == nil {
-            buffer.append(self.file.readData(ofLength: self.chunkSize))
-
+    public func findNode(withOffset offset: UInt64) throws -> BTreeNode<Key, Value> {
+        self.file.seek(toFileOffset: offset)
+        
+        let recordSizeData = self.file.readData(ofLength: lengthOfRecordSize)
+        
+        guard let recordSizeString = String(data: recordSizeData, encoding: .utf8) else {
+            throw BTreeError.invalidRecordSize
+            
         }
-
-        let nodeData = buffer.subdata(in: 0..<buffer.firstIndex(of: "\n".data(using: .utf8)!.bytes[0])!)
+        
+        guard let recordSize = Int(recordSizeString) else {
+            throw BTreeError.invalidRecordSize
+            
+        }
+        
+        let nodeData = self.file.readData(ofLength: recordSize)
 
         do {
             let node = try self.decoder.decode(BTreeNode<Key, Value>.self, from: nodeData)
@@ -179,12 +187,12 @@ public class Storage<Key: Comparable & Codable, Value: Codable> {
 
     }
 
-    /// Append a node to the current database
+    /// Append a node to the current storage
     ///
-    /// - parameter node: Node to append to the current database
+    /// - parameter node: Node to append to the current storage
     /// - returns: The offset of the provided node in storage
     /// - throws: If unable to load the given node
-    func append(_ node: BTreeNode<Key, Value>) throws -> Int {
+    func append(_ node: BTreeNode<Key, Value>) throws -> UInt64 {
         if !node.isLoaded {
             throw BTreeError.nodeIsNotLoaded
 
@@ -192,13 +200,16 @@ public class Storage<Key: Comparable & Codable, Value: Codable> {
 
         let endOfFile = self.file.seekToEndOfFile()
 
+        let encodedNode = try self.encoder.encode(node)
+        
         var dataToWrite = Data()
-        dataToWrite.append(try self.encoder.encode(node))
+        dataToWrite.append(encodedNode.count.toPaddedString().data(using: .utf8)!)
+        dataToWrite.append(encodedNode)
         dataToWrite.append(self.recordDelimiterAsData)
 
         self.file.write(dataToWrite)
 
-        return Int(endOfFile)
+        return endOfFile
 
     }
 
@@ -211,4 +222,22 @@ extension Data {
 
     }
 
+}
+
+/// To convert large unsigned ints to 0 padded strings
+extension UInt64 {
+    func toPaddedString() -> String {
+        return String(format: "%019ld", self)
+        
+    }
+    
+}
+
+/// To convert ints to 0 padded strings
+extension Int {
+    func toPaddedString() -> String {
+        return String(format: "%019d", self)
+        
+    }
+    
 }

--- a/Sources/BTree/Storage.swift
+++ b/Sources/BTree/Storage.swift
@@ -103,7 +103,7 @@ public class Storage<Key: Comparable & Codable, Value: Codable> {
         }
 
         if self.isEmpty() {
-            let zeroes = 0.toPaddedString() + "\n"
+            let zeroes = 0.toPaddedString() + self.recordDelimiter
             self.file.write(zeroes.data(using: .utf8)!)
 
         }

--- a/Tests/BTreeTests/BTreeTests.swift
+++ b/Tests/BTreeTests/BTreeTests.swift
@@ -274,7 +274,7 @@ final class BTreeTests: XCTestCase {
         
         let offset = try! storage.saveRoot(rootNode)
         
-        XCTAssertEqual(try storage.findNode(withOffset: offset).offset, 17)
+        XCTAssertEqual(try storage.findNode(withOffset: offset).offset, 19)
         
         try? FileManager.default.removeItem(at: storagePath)
         

--- a/Tests/BTreeTests/BTreeTests.swift
+++ b/Tests/BTreeTests/BTreeTests.swift
@@ -274,7 +274,7 @@ final class BTreeTests: XCTestCase {
         
         let offset = try! storage.saveRoot(rootNode)
         
-        XCTAssertEqual(try storage.findNode(withOffset: offset).offset, 19)
+        XCTAssertEqual(try storage.findNode(withOffset: offset).offset, 20)
         
         try? FileManager.default.removeItem(at: storagePath)
         


### PR DESCRIPTION
Less boilerplate is the goal here
Convert to using UInt64 for offsets in Storage
Removed all references to database or DB in Storage. Instead, referring to the file Storage stores in as Storage (say that ten times fast)